### PR TITLE
improve the urlbutton tests

### DIFF
--- a/lib/tos-urlbutton.js
+++ b/lib/tos-urlbutton.js
@@ -3,8 +3,7 @@
 
 "use strict";
 
-const tabs = require("sdk/tabs"),
-      { data } = require("sdk/self");
+const tabs = require("sdk/tabs");
 
 const { UrlbarButton } = require("urlbarbutton");
 const { panel } = require('./tos-panel');
@@ -15,14 +14,14 @@ const { iconURL } = require('./ratings');
 // create BarButton
 const button = UrlbarButton({
   id: "tosdr-checker-toolbarbutton",
-  image : data.url("class/none.png"),
-  onClick : function(){},
+  image : iconURL('none'),
+  onClick : true,
   tooltip : 'tosdr',
   panel: panel
 });
 
 function reset(url) {
-  button.setVisibility(true , url);
+  button.setVisibility(false , url);
   button.setImage(iconURL('none'), url);
 }
 

--- a/test/test-tos-urlbutton.js
+++ b/test/test-tos-urlbutton.js
@@ -3,28 +3,57 @@
 
 "use strict";
 
-const tabs = require("sdk/tabs"),
-      { data } = require("sdk/self");
+const tabs = require("sdk/tabs");
+const { setTimeout } = require('sdk/timers');
+
+const database = require('./service/database');
 
 const { button } = require('./tos-urlbutton');
 const { iconURL } = require('./ratings');
 
-const URL_500PX = "http://500px.com";
-const URL_AMAZON = "https://www.amazon.com";
-const URL_GITHUB = "https://github.com/";
+// This is the iPhone captive portal test page, its fast and simple to load
+// We fake this page to be the apple.com domain in the database
+const TEST_URL = "http://www.apple.com/library/test/success.html";
+const TEST_DOMAIN = "apple.com";
+const TEST_SERVICE = {
+  "id": "TEST",
+  "tosdr": {
+    "rated": "B"
+  },
+  "url": TEST_DOMAIN
+};
 
-exports["test urlbutton"] = function (assert, done) {
-  tabs.on("ready", function (tab) {
-    if (tab.url == URL_GITHUB) {
-      assert.equal(URL_GITHUB, tab.url, "opened the " + URL_GITHUB + " site");
-      assert.ok(button.getVisibility(tab.url), "tab urlbutton should be visible for " + URL_GITHUB);
-      // console.log("button.getImage(tab.url)", button.getImage(tab.url));
-      // assert.ok(button.getImage(tab.url), iconURL('none'), "icon should be none for " + URL_GITHUB);
-      tab.close();
-      done();
+// running this test first lets us ensure the database is primed with our TEST_SERVICE
+exports["test 1a run first test service"] = function (assert, done) {
+  let testButtonImage = function (i) { return i.src === iconURL(TEST_SERVICE.tosdr.rated); }
+  database.services.set("TEST", TEST_SERVICE).then(function () {
+    tabs.open({
+      url: TEST_URL,
+      onReady: function(tab) {
+        setTimeout(function () {
+          // setTimeout to allow the other onReady events to fire before
+          assert.ok(button.getButtons(tab.url).every(testButtonImage), "tab urlbutton should be using the correct image");
+          assert.ok(button.getVisibility(tab.url), "tab urlbutton should be visible for " + TEST_URL);
+          tab.close(done);
+        }, 10);
+      }
+    });
+  });
+}
+
+exports["test about pages"] = function (assert, done) {
+  let testButtonImage = function (i) { return i.src === iconURL('none'); }
+  tabs.open({
+    url: 'about:blank',
+    onReady: function(tab) {
+      setTimeout(function () {
+        // setTimeout to allow the other onReady events to fire before
+        assert.ok(button.getButtons(tab.url).every(testButtonImage), "tab urlbutton should be set to the none image");
+        assert.ok(! button.getVisibility(tab.url), "however the tab urlbutton should not be visible for about pages ");
+        tab.close(done);
+      }, 10);
     }
   });
-  tabs.open(URL_GITHUB);
-};
+}
 
 require('sdk/test').run(exports);


### PR DESCRIPTION
Fake a service and use a page that is faster to load than github.
Add a test to ensure the button isn’t visible for about pages.  Also
ensure the button isn’t visible for about pages.
Some other minor code updates to the tos-urlbutton module.
