### PR TITLE
Not Rated popup message update

### DIFF
--- a/data/popup.js
+++ b/data/popup.js
@@ -178,8 +178,12 @@ self.port.on('service', function onMessage(serviceData) {
     //Modal-body
     $('#page').append($("<div>", {class : 'modal-body'})
       .append($("<div>", {class : 'tosdr-rating' })
-      .append($("<h4>", { text : 'Not rated, yet.'}))
-      .append($("<p>",{ text : 'Write an email to tosdr@googlegroups.com with a link to the terms, a small quote from the terms about the point you‘re making and let us know if you think it‘s a good or a bad point. It‘s better to do one email thread by topic, rather than one email per service. For more details, read on!' , class : 'lbldesc'})))
+        .append($("<h4>", { text : 'Not rated, yet.'}))
+        .append($("<p>", { text : 'The Terms of Service of this website have not been rated yet. You can help by submitting the URL of this website to ToS;DR, or by making remarks about specific parts of it!' , class : 'lbldesc'}))
+        .append($("<a>", { href : 'https://tosdr.org/get-involved.html', target : '_blank', class : 'lbldesc'})
+          .append($("<button>", { type : 'button', text : 'Contribute'}))
+        )
+      )
     );
 
     // send close message to hide the panel


### PR DESCRIPTION
When you click the TOS;DR icon on a website which isn't indexed, it gives a popup with some information. The existing information was quite outdated: it told you to send an email with your point. This PR fixes that: it now gives some information about contributing and adds a 'Contributing' button which links to [https://tosdr.org/get-involved.html](https://tosdr.org/get-involved.html).

I didn't style the button; it might be nice to make it somewhat prettier, but imo it's usable as it is.

I didn't update the xpi binary because simply running `jpm xpi` didn't seem to result in the same kind of binary as the one provided in the root. It did result in a working plugin, though.

Old:
![Old screenshot](https://cloud.githubusercontent.com/assets/11180733/19830536/6b56dca4-9dfa-11e6-8e6d-8ad2e36f078a.png)

New:
![new](https://cloud.githubusercontent.com/assets/11180733/19831712/1ef8cfc2-9e11-11e6-9138-df2aa6a3834c.png)
