### PR TITLE
Fix the link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Moved, see https://github.com/tosdr/browser-extension
+Moved, see https://github.com/tosdr/browser-extensions


### PR DESCRIPTION
https://github.com/tosdr/browser-extension doesn't exist - the repository that was supposed to appear there was https://github.com/tosdr/browser-extensions